### PR TITLE
xml2metric: Add modem mode into provisiong status

### DIFF
--- a/connectbox_exporter/xml2metric.py
+++ b/connectbox_exporter/xml2metric.py
@@ -303,6 +303,7 @@ class ProvisioningStatus(Enum):
     PARTIAL_SERVICE_US = "Partial Service (US only)"
     PARTIAL_SERVICE_DS = "Partial Service (DS only)"
     PARTIAL_SERVICE_USDS = "Partial Service (US+DS)"
+    MODEM_MODE = "Modem Mode"
 
 
 class DeviceStatusExtractor(XmlMetricsExtractor):


### PR DESCRIPTION
* When modem mode is enabled on the router it
  contains "Modem Mode" as a provisiong status.