### PR TITLE
Github workflow to build container images

### DIFF
--- a/.github/workflows/container_image.yml
+++ b/.github/workflows/container_image.yml
@@ -1,0 +1,49 @@
+name: Build container image
+
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ main, master, dev ]
+
+  release:
+    types:
+      - "created"
+      - "edited"
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            ghcr.io/${{ github.repository_owner }}/connectbox-prometheus
+          tags: |
+            type=ref,event=pr
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to ghcr.io/$
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -17,13 +17,15 @@ On your Prometheus server host:
 
 ### Using Docker
 Alternatively you could use the provided `Dockerfile`.
-We don't provide builds on [Docker Hub](https://hub.docker.com/) or similar, so you need to `git clone` and build it yourself:
+Images can be built by cloning the repository with `git clone` and build building the image by running:
 
 `git clone https://github.com/mbugert/connectbox-prometheus.git`
 
 `cd connectbox-prometheus`
 
 Choose **either** `docker run` **or** `docker-compose`.
+
+While it is a good idea to build your own images, prebuilt images have been provided on [GitHub Container Repository](ghcr.io/mbugert/connectbox-prometheus).
 
 #### docker run
 


### PR DESCRIPTION
While it's a good idea to build containers manually, it adds additional overhead to anyone who is maintaining the exporter in a container environment. GitHub has actions and Container Registry, so maintaining a prebuilt container is no longer an overhead.

This workflow builds the container and uploads to GHCR when ever a new release is made and when a push to main or dev happens. Latter ones are useful for development flows, while the release flows will push a latest tag in addition to the release tag versions, which allows easy access to old versions as well as current versions.